### PR TITLE
Show bug in version 0.3.0

### DIFF
--- a/tests/foobar.yml
+++ b/tests/foobar.yml
@@ -1,5 +1,6 @@
 ---
 default_context: # foobar
+    # another comment
     greeting: こんにちは
     email: "raphael@hackebrot.de"
     docs: true


### PR DESCRIPTION
There is a bug in version 0.3.0 when comments directly after opening a child object will break the parser. Trying to demonstrate it with this PR.