### PR TITLE
Fixes error when the yaml file has no final blank line.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ target/
 # pyenv
 .python-version
 
+.env

--- a/poyo/parser.py
+++ b/poyo/parser.py
@@ -59,12 +59,14 @@ def log_callback(wrapped_function):
         ))
 
         return result
+
     return _wrapper
 
 
 class _Parser(object):
     def __init__(self, source):
         self.pos = 0
+        source = _Parser.__correct_missing_endline(source)
         self.source = source
         self.max_pos = len(self.source)
 
@@ -234,6 +236,28 @@ class _Parser(object):
             match = self.find_match()
             self.pos = match.end()
         return self.root()
+
+    @staticmethod
+    def __correct_missing_endline(source_text):
+        """
+        This method checks to the text for a final blank line. Without
+        this line, crazy parse errors are thrown unnecessarily. This
+        method will remove those trivial errors.
+        
+        :param source_text: The full text of the file or string to parse 
+        :return: Text correct for parse error on missing line
+        """
+        if not source_text:
+            return source_text
+
+        lines = source_text.split(u'\n')
+        if not lines:
+            return source_text
+
+        if lines[-1] != u'\n':
+            lines.append(u'\n')
+
+        return '\n'.join(lines)
 
 
 def parse_string(string):

--- a/poyo/parser.py
+++ b/poyo/parser.py
@@ -244,7 +244,7 @@ class _Parser(object):
         this line, crazy parse errors are thrown unnecessarily. This
         method will remove those trivial errors.
 
-        :param source_text: The full text of the file or string to parse 
+        :param source_text: The full text of the file or string to parse
         :return: Text correct for parse error on missing line
         """
         if not source_text:

--- a/poyo/parser.py
+++ b/poyo/parser.py
@@ -243,7 +243,7 @@ class _Parser(object):
         This method checks to the text for a final blank line. Without
         this line, crazy parse errors are thrown unnecessarily. This
         method will remove those trivial errors.
-        
+
         :param source_text: The full text of the file or string to parse 
         :return: Text correct for parse error on missing line
         """
@@ -257,7 +257,7 @@ class _Parser(object):
         if lines[-1] != u'\n':
             lines.append(u'\n')
 
-        return '\n'.join(lines)
+        return u'\n'.join(lines)
 
 
 def parse_string(string):

--- a/tests/missing_endl.yml
+++ b/tests/missing_endl.yml
@@ -1,0 +1,5 @@
+---
+default_context: # foobar
+    greeting: こんにちは
+    email: "raphael@hackebrot.de"
+    docs: true

--- a/tests/missing_open_line.yml
+++ b/tests/missing_open_line.yml
@@ -1,0 +1,4 @@
+default_context: # foobar
+    greeting: こんにちは
+    email: "raphael@hackebrot.de"
+    docs: true

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,6 +12,19 @@ def string_data():
         return ymlfile.read()
 
 
+@pytest.fixture
+def partial_file_text():
+    with codecs.open('tests/missing_endl.yml', encoding='utf-8') as ymlfile:
+        return ymlfile.read()
+
+
+@pytest.fixture
+def missing_open_line_file_text():
+    file = 'tests/missing_open_line.yml'
+    with codecs.open(file, encoding='utf-8') as ymlfile:
+        return ymlfile.read()
+
+
 def test_parse_string(string_data):
     expected = {
         u'default_context': {
@@ -37,3 +50,27 @@ def test_parse_string(string_data):
     }
 
     assert parse_string(string_data) == expected
+
+
+def test_missing_endl(partial_file_text):
+    expected = {
+        u'default_context': {
+            u'greeting': u'こんにちは',
+            u'email': u'raphael@hackebrot.de',
+            u'docs': True,
+        }
+    }
+
+    assert parse_string(partial_file_text) == expected
+
+
+def test_missing_open_line(missing_open_line_file_text):
+    expected = {
+        u'default_context': {
+            u'greeting': u'こんにちは',
+            u'email': u'raphael@hackebrot.de',
+            u'docs': True,
+        }
+    }
+
+    assert parse_string(missing_open_line_file_text) == expected


### PR DESCRIPTION
 If the YAML config file does not end with a single blank line a `NoMatch` exception is thrown with an indecipherable error. This pull request fixes that error by adding a trivial newline to the config YAML file if it is missing.