### PR TITLE
Implement failing test for list objects

### DIFF
--- a/tests/list-objects.yml
+++ b/tests/list-objects.yml
@@ -1,0 +1,5 @@
+complicated:
+  - name: Hello
+    result: World
+  - name: Question
+    result: Answer

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -94,3 +94,20 @@ def test_parse_string_lists(string_data):
         ],
     }
     assert parse_string(string_data) == expected
+
+
+@pytest.mark.parametrize('ymlfile', ['list-objects'])
+def test_parse_list_objects(string_data):
+    expected = {
+        u'complicated': {
+            u'numbers': [{
+                    u'name': u'Hello',
+                    u'result': u'World',
+                }, {
+                    u'name': u'Question',
+                    u'result': u'Answer',
+                }
+            ]
+        }
+    }
+    assert parse_string(string_data) == expected


### PR DESCRIPTION
It doesn't fix the problem, but a failing test may be a good start.

```
============================= test session starts ==============================
platform darwin -- Python 2.7.12, pytest-3.6.3, py-1.5.4, pluggy-0.6.0
rootdir: /Users/lukas/p/poyo, inifile:
collected 34 items

tests/test_parser.py ....F                                               [ 14%]
tests/test_patterns.py .............................                     [100%]

=================================== FAILURES ===================================
____________________ test_parse_list_objects[list-objects] _____________________

string_data = 'complicated:
  - name: Hello
    result: World
  - name: Question
    result: Answer
'

    @pytest.mark.parametrize('ymlfile', ['list-objects'])
    def test_parse_list_objects(string_data):
        expected = {
            u'complicated': {
                u'numbers': [{
                        u'name': u'Hello',
                        u'result': u'World',
                    }, {
                        u'name': u'Question',
                        u'result': u'Answer',
                    }
                ]
            }
        }
>       assert parse_string(string_data) == expected

tests/test_parser.py:113: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
poyo/parser.py:241: in parse_string
    return parser()
poyo/parser.py:234: in __call__
    match = self.find_match()
poyo/parser.py:214: in find_match
    node = callback(match)
poyo/parser.py:51: in _wrapper
    result = wrapped_function(parser, match, **kwargs)
poyo/parser.py:158: in parse_simple
    return Simple(variable, level, value, parent=parent)
poyo/_nodes.py:75: in __init__
    super(Simple, self).__init__(**kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[AttributeError("'Simple' object has no attribute 'name'") raised in repr()] SafeRepr object at 0x10927f9e0>
kwargs = {'parent': <Simple name: complicated, value: [u'name: Hello']>}
parent = <Simple name: complicated, value: [u'name: Hello']>

    def __init__(self, **kwargs):
        parent = kwargs['parent']
    
        if not isinstance(parent, ContainerMixin):
            raise ValueError(
>               'Parent of ChildMixin instance needs to be a Container.'
            )
E           ValueError: Parent of ChildMixin instance needs to be a Container.

poyo/_nodes.py:46: ValueError
===================== 1 failed, 33 passed in 0.11 seconds ======================
```