### PR TITLE
Adds support for Multiline Strings

### DIFF
--- a/poyo/__init__.py
+++ b/poyo/__init__.py
@@ -7,7 +7,7 @@ from .parser import parse_string
 
 __author__ = 'Raphael Pierzina'
 __email__ = 'raphael@hackebrot.de'
-__version__ = '0.4.2'
+__version__ = '0.5.0'
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 

--- a/poyo/parser.py
+++ b/poyo/parser.py
@@ -223,7 +223,10 @@ class _Parser(object):
             first_indent = int(first_indent)
         else:
             first_indent = len(lines[0]) - len(lines[0].lstrip())
-        value = self.join_lines([l[first_indent:] for l in lines], keep_newlines)
+        value = self.join_lines(
+            [l[first_indent:] for l in lines],
+            keep_newlines
+        )
         if not chomp:
             value = value.rstrip("\n") + "\n"
         elif chomp == "-":

--- a/poyo/parser.py
+++ b/poyo/parser.py
@@ -204,7 +204,7 @@ class _Parser(object):
                 result += line + concat
             else:
                 result += "\n"
-        return result.rstrip().replace(" \n", "\n")
+        return result.rstrip(" ").replace(" \n", "\n")
 
     @log_callback
     def parse_multiline_str(self, match):
@@ -218,13 +218,16 @@ class _Parser(object):
         if not lines:
             return Simple(variable, level, "", parent=parent)
 
-        first_indent = len(lines[0]) - len(lines[0].lstrip())
+        first_indent = groups['forceindent']
+        if first_indent:
+            first_indent = int(first_indent)
+        else:
+            first_indent = len(lines[0]) - len(lines[0].lstrip())
         value = self.join_lines([l[first_indent:] for l in lines], keep_newlines)
         if not chomp:
             value = value.rstrip("\n") + "\n"
         elif chomp == "-":
             value = value.rstrip("\n")
-
         return Simple(variable, level, value.rstrip(""), parent=parent)
 
     def find_match(self):

--- a/poyo/parser.py
+++ b/poyo/parser.py
@@ -11,7 +11,7 @@ from .exceptions import (
 
 from .patterns import (
     COMMENT, BLANK_LINE, DASHES, LIST, SIMPLE, SECTION,
-    LIST_ITEM, NULL, TRUE, FALSE, FLOAT, INT, STR,
+    LIST_ITEM, NULL, TRUE, FALSE, FLOAT, INT, STR, MULTILINE_STR
 )
 
 logger = logging.getLogger(__name__)
@@ -76,6 +76,7 @@ class _Parser(object):
             (BLANK_LINE, self.parse_blankline),
             (DASHES, self.parse_dashes),
             (LIST, self.parse_list),
+            (MULTILINE_STR, self.parse_multiline_str),
             (SIMPLE, self.parse_simple),
             (SECTION, self.parse_section),
         )
@@ -194,6 +195,37 @@ class _Parser(object):
     def parse_str(self, match):
         quotes = match.group('quotes')
         return match.group().strip(quotes)
+
+    def join_lines(self, lines, keep_newlines=False):
+        result = ""
+        concat = "\n" if keep_newlines else " "
+        for line in lines:
+            if line:
+                result += line + concat
+            else:
+                result += "\n"
+        return result.rstrip().replace(" \n", "\n")
+
+    @log_callback
+    def parse_multiline_str(self, match):
+        groups = match.groupdict()
+        keep_newlines = groups['blockstyle'] == "|"
+        chomp = groups['chomping']
+        level = len(groups['indent'])
+        parent = self.find_at_level(level)
+        variable = self.read_from_tag(groups['variable'])
+        lines = groups['lines'].splitlines()
+        if not lines:
+            return Simple(variable, level, "", parent=parent)
+
+        first_indent = len(lines[0]) - len(lines[0].lstrip())
+        value = self.join_lines([l[first_indent:] for l in lines], keep_newlines)
+        if not chomp:
+            value = value.rstrip("\n") + "\n"
+        elif chomp == "-":
+            value = value.rstrip("\n")
+
+        return Simple(variable, level, value.rstrip(""), parent=parent)
 
     def find_match(self):
         """Try to find a pattern that matches the source and calll a parser

--- a/poyo/patterns.py
+++ b/poyo/patterns.py
@@ -3,8 +3,10 @@
 import re
 
 _INDENT = r"(?P<indent>^ *)"
+_INDENT_MATCH = r"(?P=indent)"
 _VAR = r"(?P<variable>.+?):"
 _VALUE = r"(?P<value>(?:(?P<q2>['\"]).*?(?P=q2))|[^#]+?)"
+_STR_VALUE = r"((?:(?P<q2>['\"]).*?(?P=q2))|[^#]+?)"
 _NEWLINE = r"$\n"
 _OPT_NEWLINE = r"$\n?"
 _BLANK = r" +"
@@ -16,6 +18,10 @@ _DASHES = r"^---" + _NEWLINE
 
 _SECTION = _INDENT + _VAR + _INLINE_COMMENT + _NEWLINE
 _SIMPLE = _INDENT + _VAR + _BLANK + _VALUE + _INLINE_COMMENT + _OPT_NEWLINE
+
+_MULTILINE = _INDENT + _VAR + _BLANK + r"(?P<blockstyle>[>|])(?P<chomping>[+-]?) *" + _INLINE_COMMENT + _NEWLINE
+_MULTILINE_STR = _INDENT_MATCH + _BLANK + _STR_VALUE + _NEWLINE + r"|" + _BLANK_LINE
+_MULTILINE_SECTION = _MULTILINE + r"(?P<lines>(?:" + _MULTILINE_STR + r")*" + r")"
 
 _LIST_VALUE = (
     _BLANK + r"-" + _BLANK +
@@ -51,3 +57,4 @@ FALSE = re.compile(_FALSE)
 FLOAT = re.compile(_FLOAT)
 INT = re.compile(_INT)
 STR = re.compile(_STR)
+MULTILINE_STR = re.compile(_MULTILINE_SECTION, re.MULTILINE)

--- a/poyo/patterns.py
+++ b/poyo/patterns.py
@@ -19,9 +19,17 @@ _DASHES = r"^---" + _NEWLINE
 _SECTION = _INDENT + _VAR + _INLINE_COMMENT + _NEWLINE
 _SIMPLE = _INDENT + _VAR + _BLANK + _VALUE + _INLINE_COMMENT + _OPT_NEWLINE
 
-_MULTILINE = _INDENT + _VAR + _BLANK + r"(?P<blockstyle>[>|])(?P<chomping>[+-]?)(?P<forceindent>\d*) *" + _INLINE_COMMENT + _NEWLINE
-_MULTILINE_STR = _INDENT_MATCH + _BLANK + _STR_VALUE + _NEWLINE + r"|" + _BLANK_LINE
-_MULTILINE_SECTION = _MULTILINE + r"(?P<lines>(?:" + _MULTILINE_STR + r")*" + r")"
+_MULTILINE = (
+    _INDENT + _VAR + _BLANK +
+    r"(?P<blockstyle>[>|])(?P<chomping>[+-]?)(?P<forceindent>\d*) *" +
+    _INLINE_COMMENT + _NEWLINE
+)
+_MULTILINE_STR = (
+    _INDENT_MATCH + _BLANK + _STR_VALUE + _NEWLINE + r"|" + _BLANK_LINE
+)
+_MULTILINE_SECTION = (
+    _MULTILINE + r"(?P<lines>(?:" + _MULTILINE_STR + r")*" + r")"
+)
 
 _LIST_VALUE = (
     _BLANK + r"-" + _BLANK +

--- a/poyo/patterns.py
+++ b/poyo/patterns.py
@@ -19,7 +19,7 @@ _DASHES = r"^---" + _NEWLINE
 _SECTION = _INDENT + _VAR + _INLINE_COMMENT + _NEWLINE
 _SIMPLE = _INDENT + _VAR + _BLANK + _VALUE + _INLINE_COMMENT + _OPT_NEWLINE
 
-_MULTILINE = _INDENT + _VAR + _BLANK + r"(?P<blockstyle>[>|])(?P<chomping>[+-]?) *" + _INLINE_COMMENT + _NEWLINE
+_MULTILINE = _INDENT + _VAR + _BLANK + r"(?P<blockstyle>[>|])(?P<chomping>[+-]?)(?P<forceindent>\d*) *" + _INLINE_COMMENT + _NEWLINE
 _MULTILINE_STR = _INDENT_MATCH + _BLANK + _STR_VALUE + _NEWLINE + r"|" + _BLANK_LINE
 _MULTILINE_SECTION = _MULTILINE + r"(?P<lines>(?:" + _MULTILINE_STR + r")*" + r")"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.2
+current_version = 0.5.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 
 setup(
     name='poyo',
-    version='0.4.2',
+    version='0.5.0',
     author='Raphael Pierzina',
     author_email='raphael@hackebrot.de',
     maintainer='Raphael Pierzina',

--- a/tests/multiline-string.yml
+++ b/tests/multiline-string.yml
@@ -1,0 +1,12 @@
+Hello World:
+    multi: >
+        This is a multiline string.
+        It can contain all manners of characters.
+
+        Single line breaks are ignored,
+        but blank linkes cause line breaks.
+    withbreaks: |
+        Here we will
+        keep our linebreaks
+    chomped: >-
+        Now trailing new line here.

--- a/tests/multiline-string.yml
+++ b/tests/multiline-string.yml
@@ -8,5 +8,11 @@ Hello World:
     withbreaks: |
         Here we will
         keep our linebreaks
+    indent: >+6
+        This has two leading spaces and two trailing new lines.
+
+
     chomped: >-
         Now trailing new line here.
+
+

--- a/tests/multiline-string.yml
+++ b/tests/multiline-string.yml
@@ -4,12 +4,12 @@ Hello World:
         It can contain all manners of characters.
 
         Single line breaks are ignored,
-        but blank linkes cause line breaks.
+        but blank lines cause line breaks.
     withbreaks: |
         Here we will
         keep our linebreaks
     indent: >+6
-        This has two leading spaces and two trailing new lines.
+        This has 2 leading spaces and 2 trailing new lines.
 
 
     chomped: >-

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -94,3 +94,16 @@ def test_parse_string_lists(string_data):
         ],
     }
     assert parse_string(string_data) == expected
+
+@pytest.mark.parametrize('ymlfile', ['multiline-string'])
+def test_parse_multiline_string(string_data):
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+    expected = {
+        u"Hello World": {
+            u"multi": u"This is a multiline string. It can contain all manners of characters.\nSingle line breaks are ignored, but blank linkes cause line breaks.\n",
+            u"withbreaks": u"Here we will\nkeep our linebreaks\n",
+            u"chomped": u"Now trailing new line here.",
+        }
+    }
+    assert parse_string(string_data) == expected

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -103,6 +103,7 @@ def test_parse_multiline_string(string_data):
         u"Hello World": {
             u"multi": u"This is a multiline string. It can contain all manners of characters.\nSingle line breaks are ignored, but blank linkes cause line breaks.\n",
             u"withbreaks": u"Here we will\nkeep our linebreaks\n",
+            u"indent": u"  This has two leading spaces and two trailing new lines.\n\n",
             u"chomped": u"Now trailing new line here.",
         }
     }

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,102 +8,86 @@ from poyo import parse_string
 
 @pytest.fixture
 def string_data(ymlfile):
-    filename = 'tests/{}.yml'.format(ymlfile)
-    with codecs.open(filename, encoding='utf-8') as fh:
+    filename = "tests/{}.yml".format(ymlfile)
+    with codecs.open(filename, encoding="utf-8") as fh:
         return fh.read()
 
 
-@pytest.mark.parametrize('ymlfile', ['foobar'])
+@pytest.mark.parametrize("ymlfile", ["foobar"])
 def test_parse_string(string_data):
     expected = {
-        u'default_context': {
-            u'greeting': u'こんにちは',
-            u'email': u'raphael@hackebrot.de',
-            u'docs': True,
-            u'gui': False,
-            u'lektor': '0.0.0.0:5000',
-            u'relative-root': '/',
+        u"default_context": {
+            u"greeting": u"こんにちは",
+            u"email": u"raphael@hackebrot.de",
+            u"docs": True,
+            u"gui": False,
+            u"lektor": "0.0.0.0:5000",
+            u"relative-root": "/",
             123: 456.789,
-            u'some:int': 1000000,
-            u'foo': u'hallo #welt',
-            u'trueish': u'Falseeeeeee',
-            u'doc_tools': [u'mkdocs', u'sphinx', None],
+            u"some:int": 1000000,
+            u"foo": u"hallo #welt",
+            u"trueish": u"Falseeeeeee",
+            u"doc_tools": [u"mkdocs", u"sphinx", None],
         },
-        u'zZz': True,
-        u'NullValue': None,
-        u'Hello World': {
-            None: u'This is madness',
-            u'gh': u'https://github.com/{0}.git',
+        u"zZz": True,
+        u"NullValue": None,
+        u"Hello World": {
+            None: u"This is madness",
+            u"gh": u"https://github.com/{0}.git",
         },
-        u'Yay #python': u'Cool!'
+        u"Yay #python": u"Cool!",
     }
 
     assert parse_string(string_data) == expected
 
 
-@pytest.mark.parametrize('ymlfile', ['no-newline'])
+@pytest.mark.parametrize("ymlfile", ["no-newline"])
 def test_parse_string_no_newline(string_data):
     expected = {
-        u'Hello World': {
-            u'name': u'Toni Chu',
-            u'gh': u'https://github.com/{0}.git',
+        u"Hello World": {
+            u"name": u"Toni Chu",
+            u"gh": u"https://github.com/{0}.git"
         },
-        u'Yay #python': 3.6,
+        u"Yay #python": 3.6,
     }
     assert parse_string(string_data) == expected
 
 
-@pytest.mark.parametrize('ymlfile', ['no-newline-list'])
+@pytest.mark.parametrize("ymlfile", ["no-newline-list"])
 def test_parse_string_no_newline_list(string_data):
     expected = {
-        u'Hello World': {
-            u'numbers': [
-                1,
-                2,
-            ],
-            u'name': u'Toni Chu',
-            u'gh': u'https://github.com/{0}.git',
-            u'doc_tools': [
-                u'mkdocs',
-                u'sphinx',
-                None,
-            ]
-        },
+        u"Hello World": {
+            u"numbers": [1, 2],
+            u"name": u"Toni Chu",
+            u"gh": u"https://github.com/{0}.git",
+            u"doc_tools": [u"mkdocs", u"sphinx", None],
+        }
     }
     assert parse_string(string_data) == expected
 
 
-@pytest.mark.parametrize('ymlfile', ['lists'])
+@pytest.mark.parametrize("ymlfile", ["lists"])
 def test_parse_string_lists(string_data):
-    expected = {
-        u'a': [
-            1,
-            2,
-        ],
-        u'b': [
-            3,
-            4,
-        ],
-        u'c': [
-            5,
-            6,
-        ],
-        u'd': [
-            7,
-            8,
-        ],
-    }
+    expected = {u"a": [1, 2], u"b": [3, 4], u"c": [5, 6], u"d": [7, 8]}
     assert parse_string(string_data) == expected
 
-@pytest.mark.parametrize('ymlfile', ['multiline-string'])
+
+@pytest.mark.parametrize("ymlfile", ["multiline-string"])
 def test_parse_multiline_string(string_data):
     import logging
+
     logging.basicConfig(level=logging.DEBUG)
     expected = {
         u"Hello World": {
-            u"multi": u"This is a multiline string. It can contain all manners of characters.\nSingle line breaks are ignored, but blank linkes cause line breaks.\n",
+            u"multi": (
+                u"This is a multiline string. It can contain all manners " +
+                u"of characters.\nSingle line breaks are ignored, but blank " +
+                u"lines cause line breaks.\n"
+            ),
             u"withbreaks": u"Here we will\nkeep our linebreaks\n",
-            u"indent": u"  This has two leading spaces and two trailing new lines.\n\n",
+            u"indent": (
+                u"  This has 2 leading spaces and 2 trailing new lines.\n\n"
+            ),
             u"chomped": u"Now trailing new line here.",
         }
     }


### PR DESCRIPTION
Adds the `>` and `|` scalars to support [multiline strings](https://yaml-multiline.info/) like so:

```yaml
longtext: >
    This is a multiline string.
    It can contain all manners of characters.

    Single line breaks are ignored,
    but blank linkes cause line breaks.
```

which will be parsed as

```py
{
  "longtext": "This is a multiline string. It can contain all manners of characters.\nSingle line breaks are ignored, but blank linkes cause line breaks."
}
```

Also supports `|` for keeping line breaks, and the chomping indicators `+` and `-` for controlling trailing new lines, as well as forced indentation like

```yaml
indent: >+2
    This has two leading spaces and two trailing new lines.


next: 42
```